### PR TITLE
Add Flask backend with status endpoint

### DIFF
--- a/my-app/.gitignore
+++ b/my-app/.gitignore
@@ -22,3 +22,15 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Python
+__pycache__/
+*.py[cod]
+*.pyi
+.Python
+venv/
+.venv/
+env/
+.env
+.mypy_cache/
+.pytest_cache/

--- a/my-app/README.md
+++ b/my-app/README.md
@@ -74,6 +74,15 @@ npm run build
 3. Visit the URL printed by Vite (usually `http://localhost:5173`) to see the frontend
    displaying the backend health status.
 
+### Run both servers together (PowerShell)
+
+If you're using Windows PowerShell, you can start the backend and frontend together with a
+single command. The backend process is automatically stopped when you exit Vite.
+
+```powershell
+npm run dev:all
+```
+
 ## Available API routes
 
 | Method | Route         | Description                     |

--- a/my-app/README.md
+++ b/my-app/README.md
@@ -1,69 +1,84 @@
-# React + TypeScript + Vite
+# Driver Checker
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Driver Checker is a lightweight starter kit that combines a React + TypeScript + Vite
+frontend with a Python Flask backend. Use it as a foundation for building a richer driver
+monitoring or telematics experience.
 
-Currently, two official plugins are available:
+## Project structure
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```
+my-app/
+├── backend/            # Flask backend service
+│   ├── app.py          # Application entry point and routes
+│   └── requirements.txt
+├── public/
+├── src/                # React application source
+└── vite.config.ts      # Vite configuration (includes API proxy for development)
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+## Prerequisites
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+- [Node.js](https://nodejs.org/) 18 or newer
+- [Python](https://www.python.org/) 3.10 or newer
 
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+## Backend (Flask)
+
+Install dependencies and run the server:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # On Windows use: .venv\Scripts\activate
+pip install -r backend/requirements.txt
+python backend/app.py
 ```
+
+The backend listens on `http://localhost:5000` by default and exposes a simple health
+endpoint at `GET /api/status`.
+
+### Configuration
+
+The backend recognises the following environment variables:
+
+| Variable          | Description                                                                 |
+| ----------------- | --------------------------------------------------------------------------- |
+| `PORT`            | Overrides the default port (`5000`).                                       |
+| `FRONTEND_ORIGIN` | Restricts CORS access to the provided origin (defaults to allowing all).    |
+
+## Frontend (React + Vite)
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+The Vite dev server proxies `/api` requests to the Flask backend. For production builds or
+when the backend runs on another host, set the `VITE_API_BASE_URL` environment variable in
+an `.env` file:
+
+```
+VITE_API_BASE_URL=http://localhost:5000
+```
+
+Then build the frontend with:
+
+```bash
+npm run build
+```
+
+## Development workflow
+
+1. Start the Flask backend (`python backend/app.py`).
+2. In another terminal, run the React dev server (`npm run dev`).
+3. Visit the URL printed by Vite (usually `http://localhost:5173`) to see the frontend
+   displaying the backend health status.
+
+## Available API routes
+
+| Method | Route         | Description                     |
+| ------ | ------------- | ------------------------------- |
+| GET    | `/api/status` | Returns the backend health info |
+
+This structure gives you a solid jumping-off point for building out your own Driver
+Checker features.

--- a/my-app/backend/app.py
+++ b/my-app/backend/app.py
@@ -1,0 +1,40 @@
+"""Flask application powering the Driver Checker backend."""
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+from flask import Flask, jsonify
+from flask_cors import CORS
+
+
+def create_app() -> Flask:
+    """Create and configure the Flask application instance."""
+    app = Flask(__name__)
+
+    cors_origin = os.getenv("FRONTEND_ORIGIN")
+    cors_resources: Dict[str, Dict[str, Any]] = {
+        r"/api/*": {"origins": cors_origin or "*"}
+    }
+    CORS(app, resources=cors_resources)
+
+    @app.get("/api/status")
+    def status() -> Any:
+        """Report the health of the backend service."""
+        return jsonify(
+            {
+                "service": "Driver Checker API",
+                "status": "ok",
+                "message": "Flask backend is running and reachable.",
+            }
+        )
+
+    return app
+
+
+app = create_app()
+
+
+if __name__ == "__main__":
+    port = int(os.getenv("PORT", "5000"))
+    app.run(host="0.0.0.0", port=port)

--- a/my-app/backend/requirements.txt
+++ b/my-app/backend/requirements.txt
@@ -1,0 +1,2 @@
+Flask==3.0.3
+Flask-Cors==4.0.1

--- a/my-app/package.json
+++ b/my-app/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:all": "powershell -NoProfile -ExecutionPolicy Bypass -Command \"& { $backend = Start-Process -FilePath python -ArgumentList 'backend/app.py' -PassThru; try { npm run dev } finally { if ($backend -and -not $backend.HasExited) { Stop-Process -Id $backend.Id } } }\"",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview"

--- a/my-app/src/App.css
+++ b/my-app/src/App.css
@@ -1,42 +1,142 @@
-#root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
+.app {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+header {
   text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+header h1 {
+  margin: 0;
+  font-size: clamp(2.25rem, 5vw, 3.5rem);
+  color: #0369a1;
+  letter-spacing: -0.02em;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
+header p {
+  margin: 0 auto;
+  max-width: 720px;
+  color: #334155;
+  font-size: 1.05rem;
+}
+
+.status-card {
+  background: #ffffff;
+  border-radius: 1.25rem;
+  padding: 2rem;
+  box-shadow:
+    0 20px 45px -20px rgba(15, 23, 42, 0.35),
+    0 10px 25px -15px rgba(15, 23, 42, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.status-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.status-card h2 {
+  margin: 0;
+  font-size: 1.6rem;
+  color: #0f172a;
+}
+
+.status-card button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.55rem 1.5rem;
+  background: linear-gradient(135deg, #0ea5e9 0%, #0284c7 100%);
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+  box-shadow: 0 10px 25px -15px rgba(14, 165, 233, 0.8);
+}
+
+.status-card button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 30px -18px rgba(2, 132, 199, 0.8);
+}
+
+.status-card button:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+  box-shadow: none;
+}
+
+.status-loading {
+  margin: 0;
+  color: #0369a1;
+  font-weight: 600;
+}
+
+.status-error {
+  margin: 0;
+  color: #dc2626;
+  font-weight: 600;
+}
+
+.status-summary {
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.status-summary > div {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.4rem;
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.08), rgba(14, 165, 233, 0));
+  border-radius: 0.85rem;
+  padding: 1rem 1.15rem;
+}
+
+.status-summary dt {
+  margin: 0;
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: #64748b;
+}
+
+.status-summary dd {
+  margin: 0;
+  font-size: 1.15rem;
+  color: #0f172a;
+  word-break: break-word;
+}
+
+.status-indicator {
+  font-weight: 700;
+}
+
+.status-ok {
+  color: #16a34a;
+}
+
+.status-bad {
+  color: #dc2626;
+}
+
+@media (max-width: 600px) {
+  .status-card {
+    padding: 1.75rem 1.25rem;
   }
-  to {
-    transform: rotate(360deg);
+
+  .status-summary > div {
+    padding: 0.9rem 1rem;
   }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
 }

--- a/my-app/src/App.tsx
+++ b/my-app/src/App.tsx
@@ -1,34 +1,115 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { useCallback, useEffect, useState } from 'react'
 import './App.css'
 
+type BackendStatus = {
+  service: string
+  status: string
+  message: string
+}
+
+const buildApiUrl = (path: string) => {
+  const baseUrl = import.meta.env.VITE_API_BASE_URL
+  if (!baseUrl) {
+    return path
+  }
+
+  const sanitizedBase = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl
+  return `${sanitizedBase}${path}`
+}
+
 function App() {
-  const [count, setCount] = useState(0)
+  const [status, setStatus] = useState<BackendStatus | null>(null)
+  const [isLoading, setIsLoading] = useState<boolean>(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchStatus = useCallback(
+    async (signal?: AbortSignal) => {
+      setIsLoading(true)
+      setError(null)
+
+      try {
+        const response = await fetch(buildApiUrl('/api/status'), { signal })
+
+        if (!response.ok) {
+          throw new Error(`Backend responded with status ${response.status}`)
+        }
+
+        const payload = (await response.json()) as BackendStatus
+        setStatus(payload)
+      } catch (err) {
+        if (signal?.aborted) {
+          return
+        }
+
+        setStatus(null)
+        setError(err instanceof Error ? err.message : 'Unable to reach the backend')
+      } finally {
+        if (!signal?.aborted) {
+          setIsLoading(false)
+        }
+      }
+    },
+    [],
+  )
+
+  useEffect(() => {
+    const controller = new AbortController()
+    fetchStatus(controller.signal)
+
+    return () => {
+      controller.abort()
+    }
+  }, [fetchStatus])
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
+    <div className="app">
+      <header>
+        <h1>Driver Checker</h1>
         <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
+          A lightweight starter project that pairs a React + Vite frontend with a Python
+          Flask backend. Use it as the foundation for building richer driver monitoring
+          experiences.
         </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+      </header>
+
+      <section className="status-card">
+        <div className="status-card__header">
+          <h2>Backend status</h2>
+          <button type="button" onClick={() => fetchStatus()} disabled={isLoading}>
+            {isLoading ? 'Checking…' : 'Refresh status'}
+          </button>
+        </div>
+
+        {isLoading ? <p className="status-loading">Checking backend availability…</p> : null}
+
+        {!isLoading && error ? (
+          <p className="status-error">Unable to reach the backend: {error}</p>
+        ) : null}
+
+        {!isLoading && status ? (
+          <dl className="status-summary">
+            <div>
+              <dt>Service</dt>
+              <dd>{status.service}</dd>
+            </div>
+            <div>
+              <dt>Status</dt>
+              <dd
+                className={`status-indicator ${
+                  status.status.toLowerCase() === 'ok' ? 'status-ok' : 'status-bad'
+                }`}
+              >
+                {status.status}
+              </dd>
+            </div>
+            <div>
+              <dt>Message</dt>
+              <dd>{status.message}</dd>
+            </div>
+          </dl>
+        ) : null}
+      </section>
+    </div>
   )
 }
 

--- a/my-app/src/index.css
+++ b/my-app/src/index.css
@@ -1,68 +1,47 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
+  color: #0f172a;
+  background-color: #f8fafc;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
 }
+
+a {
+  color: #0ea5e9;
+  font-weight: 600;
+  text-decoration: none;
+}
+
 a:hover {
-  color: #535bf2;
+  color: #0369a1;
+  text-decoration: underline;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
   min-height: 100vh;
+  background: linear-gradient(180deg, #e0f2fe 0%, #f8fafc 100%);
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+#root {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem 4rem;
 }
 
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
+@media (max-width: 600px) {
+  #root {
+    padding: 2.5rem 1.25rem 3rem;
   }
 }

--- a/my-app/src/vite-env.d.ts
+++ b/my-app/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/my-app/vite.config.ts
+++ b/my-app/vite.config.ts
@@ -1,7 +1,24 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
+declare const process: {
+  cwd: () => string
+}
+
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react()],
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  const backendUrl = env.VITE_API_BASE_URL || 'http://localhost:5000'
+
+  return {
+    plugins: [react()],
+    server: {
+      proxy: {
+        '/api': {
+          target: backendUrl,
+          changeOrigin: true,
+        },
+      },
+    },
+  }
 })


### PR DESCRIPTION
## Summary
- add a Flask backend service with a health status endpoint and dependency list
- enhance the React UI to query the backend, refresh status, and apply new styling
- configure the Vite dev proxy and document backend/frontend setup instructions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cd230f60188333a74f4b229bb87805